### PR TITLE
Add LOM004 as a synonym to LOM002

### DIFF
--- a/devices.js
+++ b/devices.js
@@ -4004,7 +4004,7 @@ const devices = [
         ota: ota.zigbeeOTA,
     },
     {
-        zigbeeModel: ['LOM002'],
+        zigbeeModel: ['LOM002', 'LOM004'],
         model: '046677552343',
         vendor: 'Philips',
         description: 'Hue smart plug bluetooth',


### PR DESCRIPTION
It seems newer US Hue plugs have a Zigbee model of LOM004. The current spec sheet has the same UPC (046677552343, which is listed as the model), and the 12 number code (which is used for most of the other Hue plugs) 929002240601. On the hardware itself, it has 9290022406**X** as the model.

Other than the Zigbee model, I can't find any comparison of them that says what's different. Adding the model like this *does* make it work as expected.